### PR TITLE
fix(Error): fix for rowRef[index].ref. null

### DIFF
--- a/src/OptimizedFlatList.js
+++ b/src/OptimizedFlatList.js
@@ -22,6 +22,9 @@ export default class OptimizedFlatList extends React.PureComponent {
   }
   
   _updateItem(index, visibility){
+        if (!this.rowRefs[index].ref) {
+      return false;
+    }
     this.rowRefs[index].ref.setVisibility(visibility)
     return visibility
   }


### PR DESCRIPTION
I am using your react-native-optimized-flatlist library and ran into an error when trying to remove data rows from my array and setting a new state. The error was associated with the rowRefs[index].ref in _updateItem() with index being found as null and so we put in a small fix for this. Thanks.